### PR TITLE
Update nuget.png icon reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](nuget.png)
+![nuget.png](https://github.com/ArturWyszomirski/Plugin.Maui.Chat/blob/Documentation/nuget.png)
 # Plugin.Maui.Chat
 
 `Plugin.Maui.Chat` provides highly customizable chat control. By default colors corresponds to those set in `Resources\Styles\Colors.xaml`, but can be easily changed (see: [Customized usage](https://github.com/ArturWyszomirski/Plugin.Maui.Chat/edit/Documentation/README.md#customized-usage)).


### PR DESCRIPTION
When nuget.png is directly linked it is not shown on nuget.org. ("Some images are not displayed as they are not from trusted domains. alternate text is missing from this package README image")