### PR TITLE
Fixed spacing issue between messages on iOS, adjusted "Send" button i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Rider
+.idea/*
+*/.idea/*

--- a/sample/Plugin.Maui.Chat.Sample/Pages/CustomizedChatPage.xaml
+++ b/sample/Plugin.Maui.Chat.Sample/Pages/CustomizedChatPage.xaml
@@ -4,7 +4,9 @@
              xmlns:chat="clr-namespace:Plugin.Maui.Chat.Controls;assembly=Plugin.Maui.Chat"
              xmlns:resources="clr-namespace:Plugin.Maui.Chat.Sample.Resources"
              xmlns:viewmodels="clr-namespace:Plugin.Maui.Chat.Sample.ViewModels"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
              x:Class="Plugin.Maui.Chat.Sample.Pages.CustomizedChatPage"
+             ios:Page.UseSafeArea="True"
              Title="Customized chat"
              x:DataType="viewmodels:CustomizedChatViewModel">
     <chat:Chat UserMessage="{Binding UserMessage}"

--- a/sample/Plugin.Maui.Chat.Sample/Pages/SimpleChatPage.xaml
+++ b/sample/Plugin.Maui.Chat.Sample/Pages/SimpleChatPage.xaml
@@ -4,7 +4,9 @@
              xmlns:chat="clr-namespace:Plugin.Maui.Chat.Controls;assembly=Plugin.Maui.Chat"
              xmlns:resources="clr-namespace:Plugin.Maui.Chat.Sample.Resources"
              xmlns:viewmodels="clr-namespace:Plugin.Maui.Chat.Sample.ViewModels"
+             xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
              x:Class="Plugin.Maui.Chat.Sample.Pages.SimpleChatPage"
+             ios:Page.UseSafeArea="True"
              Title="Simple chat"
              x:DataType="viewmodels:SimpleChatViewModel">
     <chat:Chat UserMessage="{Binding UserMessage}"

--- a/sample/Plugin.Maui.Chat.Sample/Platforms/iOS/Info.plist
+++ b/sample/Plugin.Maui.Chat.Sample/Platforms/iOS/Info.plist
@@ -28,5 +28,9 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/appicon.appiconset</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 </dict>
 </plist>

--- a/src/Plugin.Maui.Chat/Controls/Chat.xaml
+++ b/src/Plugin.Maui.Chat/Controls/Chat.xaml
@@ -88,6 +88,8 @@
                                              SystemMessage="{StaticResource SystemMessageTemplate}"/>
     </ContentView.Resources>
 
+    
+    <!-- UI -->
     <Grid RowDefinitions="*, Auto, Auto"
           RowSpacing="10">
         <ScrollView x:Name="chatMessagesScrollView" 
@@ -95,7 +97,11 @@
                     VerticalOptions="End">
             <CollectionView x:Name="chatMessagesCollectionView"
                             ItemsSource="{Binding ChatMessages, Source={x:Reference chat}}"
-                            ItemTemplate="{StaticResource ChatMessageTemplateSelector}"/>
+                            ItemTemplate="{StaticResource ChatMessageTemplateSelector}">
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Vertical" ItemSpacing="{OnPlatform Android=0, iOS=10, Default=10}" />
+                </CollectionView.ItemsLayout>
+            </CollectionView>
         </ScrollView>
         <Label Grid.Row="1"
                Text="{Binding Status, Source={x:Reference chat}}"
@@ -166,12 +172,13 @@
                 </Grid>
             </Frame>
             <ImageButton Grid.Column="1"
-                         Command="{Binding SendMessageCommand, Source={x:Reference chat}}"
+                   Command="{Binding SendMessageCommand, Source={x:Reference chat}}"
                    HeightRequest="25"
                    WidthRequest="25"
+                   Padding="{OnPlatform iOS=5, Default=0}"
                    Source="{Binding SendMessageIcon, Source={x:Reference chat}}" 
-                   Aspect="AspectFit"
-                         IsEnabled="{Binding IsSendMessageEnabled, Source={x:Reference chat}}"
+                   Aspect="{OnPlatform iOS=Fill, Default=AspectFit}"
+                   IsEnabled="{Binding IsSendMessageEnabled, Source={x:Reference chat}}"
                    IsVisible="{Binding IsSendMessageVisible, Source={x:Reference chat}}">
                 <ImageButton.Behaviors>
                     <toolkit:IconTintColorBehavior TintColor="{Binding SendMessageColor, Source={x:Reference chat}}"/>


### PR DESCRIPTION
- Adjusted the image size of the "Send" button for consistent UI across platforms
- Added "fetch" to UIBackgroundModes in the iOS sample's Info.plist for background task support
- Fixed the spacing between messages in CollectionView on iOS, but new issue.

I found a few more issues.
-There is an issue with automatic scrolling to the bottom of the screen. It works when sending a message, but when replying to Echo, the second scroll is either canceled or triggered before the item is added.
-There is an issue with the height of the CollectionView after adding padding when the first message is loaded. (This is noticeable in the difference in screenshots where the oldest message is cut off after changes). The problem disappears, for example, when the keyboard is pulled up or when you tap on the editor.

If you like it, don't merge it for now. I'll take a look at these issues tomorrow or the day after.

Before
![Simulator Screenshot - iPhone 15 - 2024-09-10 at 20 02 07](https://github.com/user-attachments/assets/0267cb0a-599d-4a5f-86e7-a59d6e3f3285)

After
![Simulator Screenshot - iPhone 15 - 2024-09-10 at 20 01 08](https://github.com/user-attachments/assets/fa5b2d8d-dbe8-47ab-9a8b-e99f2071a469)


