### PR TITLE
Fix send message button behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ All you have to do to get started is to deal with those three properties:
 - `TextContent` of string type which holds the user input,
 - `SendMessageCommand` where you decide what happens after firing Send message button.
 
+> [!NOTE]
+> Send messagge button is disabled if message content is empty or chat is recording, transcribing or hands-free mode is on. This behavior can be overwritten by setting `IsSendMessageEnabled` property.
+
 Example below shows how to bind properties. In this scenario every sent message will be repeated and send back after 1 second.
 
 View:
@@ -138,7 +141,7 @@ async Task SendMessageAsync()
   <img src="./assets/screenshots/audio_chat_05.png" alt="Thumbnail" width="200">
 </a>
 
-> [!NOTE]
+> [!WARNING]
 > To use voice messaging setting relevant permissions to record audio is necessary.
 
 `Chat` provides built-in functionality for voice messaging based on `Plugin.Maui.Audio`. Audio Recorder is equipped in silence detection, so recording should stop automatically when user stops speaking.
@@ -341,10 +344,8 @@ TakePhotoColor="{StaticResource Primary}"
 
 ##### Send message button
 
-By default button is disabled when user text entry is empty or consist only whitespace characters and no other content is present in the message.
-
 > [!NOTE]
-> This behavior can be changed by setting the `IsSendMessageEnabled` property.
+> Send messagge button is disabled if message content is empty or chat is recording, transcribing or hands-free mode is on. This behavior can be overwritten by settind `IsSendMessageEnabled` property.
 
 ```xaml
 SendMessageCommand="{Binding SendMessageCommand}"
@@ -364,13 +365,54 @@ Services used by `Chat` are exposed through relevant properties. This enables ei
 > See how to use your own services in `CustomizedViewModel` sample.
 
 #### `AudioService`: 
+
 Implements `IAudioService`. Utilizes `Plugin.Maui.Audio`. Responsible for recording and playing audio.
 
+##### Properties
+
+`IsRecording` - shows whether audio is being currently recorded.
+
+`SoundDetected` - set to true if there was a sound detected in latest recording in the latest recording (updated after recording is finished).
+
+`IsPlaying` - shows whether audio is being currently played.
+
+##### Methods
+
+`Task<IAudioSource?> StartRecordingAsync(bool silenceDetection = true, double silenceTreshold = 2, TimeSpan silenceDuration = default)` - fired when audio recorder button is pressed, `IsRecording = false` and `IsSpeechToTextEnabled = false`.
+
+`Task<IAudioSource?> StopRecordingAsync()` - fired when audio redorder button is pressed, `IsRecording = true` and `IsSpeechToTextEnabled = false`.
+
+`Task StartPlayingAsync(IAudioSource? audioSource)` - fired when audio player button is pressed and `IsPlaying = false`.
+    
+`void StopPlaying()` - fired when audio player button is pressed and `IsPlaying = true`.
+
 #### `SpeechToTextService`:
+
 Implements `ISpeechToTextService`. Utilizes `CommunityToolkit`'s speech-to-text feature. Responsible for speech transcription.
 
+##### Properties
+
+`IsTranscribing` - shows whether speech is currently being transcribed.
+
+##### Methods
+
+`Task<string?> StartTranscriptionAsync()` - fired when audio recorder button is pressed, `IsTransribing = false`, and `IsSpeechToTextEnabled = true`.
+
+`Task<string?> StopTranscriptionAsync()` - fired when audio recorder button is pressed, `IsTransribing = true`, and `IsSpeechToTextEnabled = true`.
+
 #### `TextToSpeechService`:
+
 Implements `ITextToSpeechService`. Utilizes MAUI's native text-to-speech feature. Responsible for reading text.
+
+##### Properties
+
+`IsReading` - shows whether text message is currently being read.
+
+##### Methods
+
+`Task StartReadingAsync(string? text)` - fired when text reader button is pressed, `IsReading = false`.
+
+`void StopReading()` - fired when text reader button is pressed, `IsReading = true`.
 
 ## Credits
 

--- a/src/Plugin.Maui.Chat/Behaviors/SendMessageButtonEnableBehavior.cs
+++ b/src/Plugin.Maui.Chat/Behaviors/SendMessageButtonEnableBehavior.cs
@@ -21,7 +21,16 @@ internal class SendMessageButtonEnableBehavior : Behavior<Controls.Chat>
     {
         var chat = sender as Controls.Chat ?? throw new ArgumentNullException(nameof(sender));
 
-        if (e.PropertyName == Controls.Chat.TextContentProperty.PropertyName || e.PropertyName == Controls.Chat.AudioContentProperty.PropertyName)
-            chat.IsSendMessageEnabled = (!string.IsNullOrWhiteSpace(chat?.TextContent) || (chat?.AudioContent is not null)) && !chat.IsHandsFreeModeOn;
+        if (e.PropertyName == Controls.Chat.TextContentProperty.PropertyName
+            || e.PropertyName == Controls.Chat.AudioContentProperty.PropertyName
+            || e.PropertyName == Controls.Chat.IsRecordingProperty.PropertyName
+            || e.PropertyName == Controls.Chat.IsTranscribingProperty.PropertyName
+            || e.PropertyName == Controls.Chat.IsHandsFreeModeOnProperty.PropertyName)
+        {
+            chat.IsSendMessageEnabled = (!string.IsNullOrWhiteSpace(chat?.TextContent) || (chat?.AudioContent is not null))
+                && !chat.IsRecording
+                && !chat.IsTranscribing
+                && !chat.IsHandsFreeModeOn;
+        }
     }
 }

--- a/src/Plugin.Maui.Chat/Controls/Chat.xaml.cs
+++ b/src/Plugin.Maui.Chat/Controls/Chat.xaml.cs
@@ -879,11 +879,13 @@ public partial class Chat : ContentView
         if (bindable is Chat chat)
             chat.Status = (bool)newValue ? "Transcribing..." : string.Empty;
     }
+
     private static void OnIsPlayingChanged(BindableObject bindable, object oldValue, object newValue)
     {
         if (bindable is Chat chat)
             chat.Status = (bool)newValue ? "Playing..." : string.Empty;
     }
+
     private static void OnIsReadingChanged(BindableObject bindable, object oldValue, object newValue)
     {
         if (bindable is Chat chat)


### PR DESCRIPTION
Fix send message button was not always disabled when recorder, transcription or hands-free mode was on.
Updated documentation on this and additionally updated section about services.